### PR TITLE
Allow the cilium-olm service account to manage monitoring.coreos.com/servicemonitors resources

### DIFF
--- a/config/operator/rbac.cue
+++ b/config/operator/rbac.cue
@@ -332,6 +332,18 @@ _helmOperatorRules: [
 			"*",
 		]
 	},
+	{
+		// Operator needs to manage servicemonitors if prometheus is enabled
+		apiGroups: [
+			"monitoring.coreos.com",
+		]
+		resources: [
+			"servicemonitors",
+		]
+		verbs: [
+			"*",
+		]
+	},
 ]
 
 _commonSubjects: [{


### PR DESCRIPTION
When prometheus is enabled via the `CiliumConfig`:
```
spec:
  operator:
    prometheus:
      enabled: true
      serviceMonitor:
        enabled: true
  prometheus:
    enabled: true
    serviceMonitor:
      enabled: true
```

the `cilium-olm` pod starts failing with:
```
2022-03-25T04:06:43.436Z	ERROR	controller-runtime.manager.controller.ciliumconfig-controller	Reconciler error	{"name": "cilium", "namespace": "cilium", "error": "failed to get candidate release: rendered manifests contain a resource that already exists. Unable to continue with update: could not get information about the resource: servicemonitors.monitoring.coreos.com \"cilium-agent\" is forbidden: User \"system:serviceaccount:cilium:cilium-olm\" cannot get resource \"servicemonitors\" in API group \"monitoring.coreos.com\" in the namespace \"cilium\": RBAC: role.rbac.authorization.k8s.io \"leader-election\" not found"}
github.com/go-logr/zapr.(*zapLogger).Error
	/go/pkg/mod/github.com/go-logr/zapr@v0.2.0/zapr.go:132
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.8.2/pkg/internal/controller/controller.go:301
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.8.2/pkg/internal/controller/controller.go:252
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func1.2
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.8.2/pkg/internal/controller/controller.go:215
k8s.io/apimachinery/pkg/util/wait.JitterUntilWithContext.func1
	/go/pkg/mod/k8s.io/apimachinery@v0.20.2/pkg/util/wait/wait.go:185
k8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1
	/go/pkg/mod/k8s.io/apimachinery@v0.20.2/pkg/util/wait/wait.go:155
k8s.io/apimachinery/pkg/util/wait.BackoffUntil
	/go/pkg/mod/k8s.io/apimachinery@v0.20.2/pkg/util/wait/wait.go:156
k8s.io/apimachinery/pkg/util/wait.JitterUntil
	/go/pkg/mod/k8s.io/apimachinery@v0.20.2/pkg/util/wait/wait.go:133
k8s.io/apimachinery/pkg/util/wait.JitterUntilWithContext
	/go/pkg/mod/k8s.io/apimachinery@v0.20.2/pkg/util/wait/wait.go:185
k8s.io/apimachinery/pkg/util/wait.UntilWithContext
	/go/pkg/mod/k8s.io/apimachinery@v0.20.2/pkg/util/wait/wait.go:99
```