### PR TITLE
fix(operator): allow operator to managed ingress objects

### DIFF
--- a/config/operator/rbac.cue
+++ b/config/operator/rbac.cue
@@ -344,6 +344,18 @@ _helmOperatorRules: [
 			"*",
 		]
 	},
+	{
+		// Operator needs to manage ingresses if ingress for hubble-ui is enabled
+		apiGroups: [
+			"networking.k8s.io",
+		]
+		resources: [
+			"ingresses",
+		]
+		verbs: [
+			"*",
+		]
+	},
 ]
 
 _commonSubjects: [{


### PR DESCRIPTION
I'm not 100% confident if this is the correct approach, as I believe this would grant the operator privileges on all ingress resources in the whole cluster, but I think it's good to start a discussion about how to extend those privileges.

fixes #78