### PR TITLE
conformance: Don't enable pprof

### DIFF
--- a/ciliumconfig.conformance.yaml
+++ b/ciliumconfig.conformance.yaml
@@ -8,8 +8,6 @@ spec:
     enabled: true
   k8s:
     requireIPv4PodCIDR: true
-  pprof:
-    enabled: true
   logSystemLoad: true
   bpf:
     preallocateMaps: true


### PR DESCRIPTION
It seems to cause etcd-health-monitor container to fail with this error:

    F0224 00:12:05.105658       1 profiler.go:22] listen tcp 127.0.0.1:6060: bind: address already in use