### PR TITLE
v1.11.14: Use SHA instead of image tag

### DIFF
--- a/bundles/cilium.v1.11.14/manifests/cilium.clusterserviceversion.yaml
+++ b/bundles/cilium.v1.11.14/manifests/cilium.clusterserviceversion.yaml
@@ -192,7 +192,7 @@ spec:
                   value: quay.io/cilium/startup-script@sha256:1daf817f34000399fcb5da9a94cb299e2810d2c7a52e51de22ba0d4783b6ce84
                 - name: RELATED_IMAGE_CLUSTERMESH_ETCD
                   value: quay.io/coreos/etcd@sha256:a17abff8fa908eb6aaecd0367c0154b73a8a66e484100e91202319bc1d9a7cd3
-                image: registry.connect.redhat.com/isovalent/cilium-olm:4714c804808245f72a26ee126f753d00b3d2eaff-v1.11.14
+                image: registry.connect.redhat.com/isovalent/cilium-olm@sha256:d7490a73c5f7861ae13af5e5770a8a7cf8a0477fe250a97f0ea8ee673969fd11
                 name: operator
                 ports:
                 - containerPort: 9443
@@ -341,4 +341,5 @@ spec:
     name: nodeinit
   - image: quay.io/coreos/etcd@sha256:a17abff8fa908eb6aaecd0367c0154b73a8a66e484100e91202319bc1d9a7cd3
     name: clustermesh-etcd
+  replaces: cilium.v1.11.7-x4537d91
   version: 1.11.14+x26761c4

--- a/manifests/cilium.v1.11.14/cluster-network-06-cilium-00002-cilium-olm-deployment.yaml
+++ b/manifests/cilium.v1.11.14/cluster-network-06-cilium-00002-cilium-olm-deployment.yaml
@@ -52,7 +52,7 @@ spec:
           value: quay.io/cilium/startup-script@sha256:1daf817f34000399fcb5da9a94cb299e2810d2c7a52e51de22ba0d4783b6ce84
         - name: RELATED_IMAGE_CLUSTERMESH_ETCD
           value: quay.io/coreos/etcd@sha256:a17abff8fa908eb6aaecd0367c0154b73a8a66e484100e91202319bc1d9a7cd3
-        image: registry.connect.redhat.com/isovalent/cilium-olm:4714c804808245f72a26ee126f753d00b3d2eaff-v1.11.14
+        image: registry.connect.redhat.com/isovalent/cilium-olm@sha256:d7490a73c5f7861ae13af5e5770a8a7cf8a0477fe250a97f0ea8ee673969fd11
         name: operator
         ports:
         - containerPort: 9443

--- a/manifests/cilium.v1.11.14/cluster-network-06-cilium-00014-cilium.v1.11.14-x26761c4-clusterserviceversion.yaml
+++ b/manifests/cilium.v1.11.14/cluster-network-06-cilium-00014-cilium.v1.11.14-x26761c4-clusterserviceversion.yaml
@@ -192,7 +192,7 @@ spec:
                   value: quay.io/cilium/startup-script@sha256:1daf817f34000399fcb5da9a94cb299e2810d2c7a52e51de22ba0d4783b6ce84
                 - name: RELATED_IMAGE_CLUSTERMESH_ETCD
                   value: quay.io/coreos/etcd@sha256:a17abff8fa908eb6aaecd0367c0154b73a8a66e484100e91202319bc1d9a7cd3
-                image: registry.connect.redhat.com/isovalent/cilium-olm:4714c804808245f72a26ee126f753d00b3d2eaff-v1.11.14
+                image: registry.connect.redhat.com/isovalent/cilium-olm@sha256:d7490a73c5f7861ae13af5e5770a8a7cf8a0477fe250a97f0ea8ee673969fd11
                 name: operator
                 ports:
                 - containerPort: 9443


### PR DESCRIPTION
Also add `replace` section based on:

    % opm alpha list channels registry.redhat.io/redhat/certified-operator-index:v4.11 cilium | grep v1.11
    cilium   1.11     cilium.v1.11.7-x4537d91

Ref: https://catalog.redhat.com/software/containers/isovalent/cilium-olm/5ff7310e293738682042b1dd?tag=4714c804808245f72a26ee126f753d00b3d2eaff-v1.11.14