### PR TITLE
v1.13.0: Use SHA instead of image tag

### DIFF
--- a/bundles/cilium.v1.13.0/manifests/cilium.clusterserviceversion.yaml
+++ b/bundles/cilium.v1.13.0/manifests/cilium.clusterserviceversion.yaml
@@ -201,7 +201,7 @@ spec:
                         value: quay.io/cilium/startup-script@sha256:c263d1678fb426842c0836358c1da7628d771126211694a3776c4b8500cbb215
                       - name: RELATED_IMAGE_CLUSTERMESH_ETCD
                         value: quay.io/coreos/etcd@sha256:a67fb152d4c53223e96e818420c37f11d05c2d92cf62c05ca5604066c37295e9
-                    image: registry.connect.redhat.com/isovalent/cilium-olm:1d7a8e5db7b702b7d1a9b6ce84a43057c751d07a-v1.13.0
+                    image: registry.connect.redhat.com/isovalent/cilium-olm@sha256:aed05a332413c8244b615d6b2f013e4fbc5ce7f65ed7f83213bc3605ae4dedce
                     name: operator
                     ports:
                       - containerPort: 9443

--- a/manifests/cilium.v1.13.0/cluster-network-06-cilium-00002-cilium-olm-deployment.yaml
+++ b/manifests/cilium.v1.13.0/cluster-network-06-cilium-00002-cilium-olm-deployment.yaml
@@ -52,7 +52,7 @@ spec:
               value: quay.io/cilium/startup-script@sha256:c263d1678fb426842c0836358c1da7628d771126211694a3776c4b8500cbb215
             - name: RELATED_IMAGE_CLUSTERMESH_ETCD
               value: quay.io/coreos/etcd@sha256:a67fb152d4c53223e96e818420c37f11d05c2d92cf62c05ca5604066c37295e9
-          image: registry.connect.redhat.com/isovalent/cilium-olm:1d7a8e5db7b702b7d1a9b6ce84a43057c751d07a-v1.13.0
+          image: registry.connect.redhat.com/isovalent/cilium-olm@sha256:aed05a332413c8244b615d6b2f013e4fbc5ce7f65ed7f83213bc3605ae4dedce
           name: operator
           ports:
             - containerPort: 9443

--- a/manifests/cilium.v1.13.0/cluster-network-06-cilium-00014-cilium.v1.13.0-x32540df-clusterserviceversion.yaml
+++ b/manifests/cilium.v1.13.0/cluster-network-06-cilium-00014-cilium.v1.13.0-x32540df-clusterserviceversion.yaml
@@ -201,7 +201,7 @@ spec:
                         value: quay.io/cilium/startup-script@sha256:c263d1678fb426842c0836358c1da7628d771126211694a3776c4b8500cbb215
                       - name: RELATED_IMAGE_CLUSTERMESH_ETCD
                         value: quay.io/coreos/etcd@sha256:a67fb152d4c53223e96e818420c37f11d05c2d92cf62c05ca5604066c37295e9
-                    image: registry.connect.redhat.com/isovalent/cilium-olm:1d7a8e5db7b702b7d1a9b6ce84a43057c751d07a-v1.13.0
+                    image: registry.connect.redhat.com/isovalent/cilium-olm@sha256:aed05a332413c8244b615d6b2f013e4fbc5ce7f65ed7f83213bc3605ae4dedce
                     name: operator
                     ports:
                       - containerPort: 9443


### PR DESCRIPTION
https://catalog.redhat.com/software/containers/isovalent/cilium-olm/5ff7310e293738682042b1dd?tag=1d7a8e5db7b702b7d1a9b6ce84a43057c751d07a-v1.13.0